### PR TITLE
add import Tags

### DIFF
--- a/cdk/app.py
+++ b/cdk/app.py
@@ -5,7 +5,7 @@ import os
 import aws_cdk as cdk
 from aws_cdk import (
     # Duration,
-    App, CfnOutput, Stack, Environment, Fn,
+    App, CfnOutput, Stack, Environment, Fn, Tags,
     aws_ec2 as ec2,
     aws_ecs as ecs,
     aws_iam as iam,


### PR DESCRIPTION
In the hands-on [Deploy an EC2 Spot Capacity Provider,](https://ecsworkshop.com/capacity_providers/ec2_spot/#:~:text=Enable%20EC2%20Spot%20capacity%20on%20the%20cluster) there was an error due to insufficient Import.
So I'm requesting a fix.